### PR TITLE
remove prism code-blocks

### DIFF
--- a/website/plugins/remark-snackplayer/README.md
+++ b/website/plugins/remark-snackplayer/README.md
@@ -47,5 +47,4 @@ Parameters:
 ## To Do
 
 - Support Passing Configuration Parameters
-- Fix and Document Mobile Fallback
 - Write Comprehensive tests

--- a/website/plugins/remark-snackplayer/package.json
+++ b/website/plugins/remark-snackplayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-snackplayer",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Remark SnackPlayer Plugin",
   "main": "src/index.js",
   "author": "Darsh <darshkpatel@gmail.com>",
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "dedent": "^0.7.0",
-    "prismjs": "^1.21.0",
     "unist-builder": "^2.0.3",
     "unist-util-visit-parents": "^3.1.0"
   },

--- a/website/plugins/remark-snackplayer/src/index.js
+++ b/website/plugins/remark-snackplayer/src/index.js
@@ -2,8 +2,6 @@
 const visit = require('unist-util-visit-parents');
 const u = require('unist-builder');
 const dedent = require('dedent');
-const Prism = require('prismjs');
-require('prismjs/components/prism-jsx');
 
 function parseParams(paramString) {
   var params = {};
@@ -21,16 +19,6 @@ function parseParams(paramString) {
   }
 
   return params;
-}
-
-function htmlForCodeBlock(code) {
-  return `
-    <pre class="language-jsx">
-      <code class="language-jsx">
-    ${Prism.highlight(code, Prism.languages.jsx, 'jsx')}
-      </code>
-    </pre>
-    `;
 }
 
 function SnackPlayer() {
@@ -64,20 +52,15 @@ function SnackPlayer() {
                 const snackPlayerDiv = u('html', {
                   value: dedent`
                 <div class="snack-player">
-                  <div class="mobile-friendly-snack" style="display: none">
-                    ${htmlForCodeBlock(dedent(sampleCode))}
-                  </div>
-                  <div class="desktop-friendly-snack">
-                    <div
-                      data-snack-name="${name}"
-                      data-snack-description="${description}"
-                      data-snack-code="${encodedSampleCode}"
-                      data-snack-platform="${platform}"
-                      data-snack-supported-platforms="${supportedPlatforms}"
-                      data-snack-preview="true"
-                      style="overflow:hidden;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
-                      >
-                    </div>
+                  <div
+                    data-snack-name="${name}"
+                    data-snack-description="${description}"
+                    data-snack-code="${encodedSampleCode}"
+                    data-snack-platform="${platform}"
+                    data-snack-supported-platforms="${supportedPlatforms}"
+                    data-snack-preview="true"
+                    style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
+                    >
                   </div>
                 </div>
                 `,
@@ -100,52 +83,7 @@ function SnackPlayer() {
         // To embed.js script
         const snackPlayerEmbed = u('html', {
           value: dedent`
-          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prism-solarized-dark@1.0.1/prism-solarizeddark.css">         
-          <script type="text/javascript">
-          // From: 
-          (function() {
-            'use strict';
-            if (typeof document === 'undefined') {
-              // Not on browser
-              return;
-            }
-            document.addEventListener('DOMContentLoaded', init);
-
-            function init() {
-              var mobile = isMobile();
-
-              window.ExpoSnack && window.ExpoSnack.initialize();
-
-              var snackPlayerList = document.querySelectorAll('.snack-player');
-
-              // Either show interactive or static code block, depending on desktop or mobile
-              for (var i = 0; i < snackPlayerList.length; ++i) {
-                var snackPlayer = snackPlayerList[i];
-                var snackDesktopPlayer = snackPlayer.querySelectorAll(
-                  '.desktop-friendly-snack'
-                )[0];
-                var plainCodeExample = snackPlayer.querySelectorAll(
-                  '.mobile-friendly-snack'
-                )[0];
-
-                if (mobile) {
-                  snackDesktopPlayer.remove();
-                  plainCodeExample.style.display = 'block';
-                } else {
-                  plainCodeExample.remove();
-                }
-              }
-            }
-            
-              // Primitive mobile detection
-              function isMobile() {
-                return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-                  navigator.userAgent
-                );
-              }
-              
-          })();
-        </script>
+          <script async src="https://snack.expo.io/embed.js"></script>
           `,
         });
 

--- a/website/plugins/remark-snackplayer/tests/output/output1.html
+++ b/website/plugins/remark-snackplayer/tests/output/output1.html
@@ -1,83 +1,13 @@
 <div class="snack-player">
-  <div class="mobile-friendly-snack" style="display: none">
-    <pre class="language-jsx">
-  <code class="language-jsx">
-<span class="token keyword">import</span> React <span class="token keyword">from</span> <span class="token string">'react'</span><span class="token punctuation">;</span>
-<span class="token keyword">import</span> <span class="token punctuation">{</span> Text<span class="token punctuation">,</span> View <span class="token punctuation">}</span> <span class="token keyword">from</span> <span class="token string">'react-native'</span><span class="token punctuation">;</span>
-
-<span class="token keyword">const</span> <span class="token function-variable function">YourApp</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=></span> <span class="token punctuation">{</span>
-<span class="token keyword">return</span> <span class="token punctuation">(</span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">View</span></span> <span class="token attr-name">style</span><span class="token script language-javascript"><span class="token script-punctuation punctuation">=</span><span class="token punctuation">{</span><span class="token punctuation">{</span> flex<span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span> justifyContent<span class="token operator">:</span> <span class="token string">"center"</span><span class="token punctuation">,</span> alignItems<span class="token operator">:</span> <span class="token string">"center"</span> <span class="token punctuation">}</span><span class="token punctuation">}</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-Try editing me! 🎉
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">View</span></span><span class="token punctuation">></span></span>
-<span class="token punctuation">)</span><span class="token punctuation">;</span>
-<span class="token punctuation">}</span>
-
-<span class="token keyword">export</span> <span class="token keyword">default</span> YourApp<span class="token punctuation">;</span>
-  </code>
-</pre>
-  </div>
-  <div class="desktop-friendly-snack">
-    <div
-      data-snack-name="Hello World"
-      data-snack-description="Example usage"
-      data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
-      data-snack-platform="web"
-      data-snack-supported-platforms="ios,android,web"
-      data-snack-preview="true"
-      style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
-    ></div>
-  </div>
+  <div
+    data-snack-name="Hello World"
+    data-snack-description="Example usage"
+    data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
+    data-snack-platform="web"
+    data-snack-supported-platforms="ios,android,web"
+    data-snack-preview="true"
+    style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
+  ></div>
 </div>
 
 <script async src="https://snack.expo.io/embed.js"></script>
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/prism-solarized-dark@1.0.1/prism-solarizeddark.css"
-/>
-<script type="text/javascript">
-  // From:
-  (function() {
-    "use strict";
-    if (typeof document === "undefined") {
-      // Not on browser
-      return;
-    }
-    document.addEventListener("DOMContentLoaded", init);
-
-    function init() {
-      var mobile = isMobile();
-
-      window.ExpoSnack && window.ExpoSnack.initialize();
-
-      var snackPlayerList = document.querySelectorAll(".snack-player");
-
-      // Either show interactive or static code block, depending on desktop or mobile
-      for (var i = 0; i < snackPlayerList.length; ++i) {
-        var snackPlayer = snackPlayerList[i];
-        var snackDesktopPlayer = snackPlayer.querySelectorAll(
-          ".desktop-friendly-snack"
-        )[0];
-        var plainCodeExample = snackPlayer.querySelectorAll(
-          ".mobile-friendly-snack"
-        )[0];
-
-        if (mobile) {
-          snackDesktopPlayer.remove();
-          plainCodeExample.style.display = "block";
-        } else {
-          plainCodeExample.remove();
-        }
-      }
-    }
-
-    // Primitive mobile detection
-    function isMobile() {
-      return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      );
-    }
-  })();
-</script>

--- a/website/plugins/remark-snackplayer/tests/output/output2.html
+++ b/website/plugins/remark-snackplayer/tests/output/output2.html
@@ -1,117 +1,25 @@
 <div class="snack-player">
-  <div class="mobile-friendly-snack" style="display: none">
-    <pre class="language-jsx">
-  <code class="language-jsx">
-<span class="token keyword">import</span> React <span class="token keyword">from</span> <span class="token string">'react'</span><span class="token punctuation">;</span>
-<span class="token keyword">import</span> <span class="token punctuation">{</span> Text<span class="token punctuation">,</span> View <span class="token punctuation">}</span> <span class="token keyword">from</span> <span class="token string">'react-native'</span><span class="token punctuation">;</span>
-
-<span class="token keyword">const</span> <span class="token function-variable function">YourApp</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=></span> <span class="token punctuation">{</span>
-<span class="token keyword">return</span> <span class="token punctuation">(</span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">View</span></span> <span class="token attr-name">style</span><span class="token script language-javascript"><span class="token script-punctuation punctuation">=</span><span class="token punctuation">{</span><span class="token punctuation">{</span> flex<span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span> justifyContent<span class="token operator">:</span> <span class="token string">"center"</span><span class="token punctuation">,</span> alignItems<span class="token operator">:</span> <span class="token string">"center"</span> <span class="token punctuation">}</span><span class="token punctuation">}</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-Try editing me! 🎉
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">View</span></span><span class="token punctuation">></span></span>
-<span class="token punctuation">)</span><span class="token punctuation">;</span>
-<span class="token punctuation">}</span>
-
-<span class="token keyword">export</span> <span class="token keyword">default</span> YourApp<span class="token punctuation">;</span>
-  </code>
-</pre>
-  </div>
-  <div class="desktop-friendly-snack">
-    <div
-      data-snack-name="FirstPlayer"
-      data-snack-description="Example usage"
-      data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
-      data-snack-platform="web"
-      data-snack-supported-platforms="ios,android,web"
-      data-snack-preview="true"
-      style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
-    ></div>
-  </div>
+  <div
+    data-snack-name="FirstPlayer"
+    data-snack-description="Example usage"
+    data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
+    data-snack-platform="web"
+    data-snack-supported-platforms="ios,android,web"
+    data-snack-preview="true"
+    style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
+  ></div>
 </div>
 
 <div class="snack-player">
-  <div class="mobile-friendly-snack" style="display: none">
-    <pre class="language-jsx">
-  <code class="language-jsx">
-<span class="token keyword">import</span> React <span class="token keyword">from</span> <span class="token string">'react'</span><span class="token punctuation">;</span>
-<span class="token keyword">import</span> <span class="token punctuation">{</span> Text<span class="token punctuation">,</span> View <span class="token punctuation">}</span> <span class="token keyword">from</span> <span class="token string">'react-native'</span><span class="token punctuation">;</span>
-
-<span class="token keyword">const</span> <span class="token function-variable function">YourApp</span> <span class="token operator">=</span> <span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token operator">=></span> <span class="token punctuation">{</span>
-<span class="token keyword">return</span> <span class="token punctuation">(</span>
-<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">View</span></span> <span class="token attr-name">style</span><span class="token script language-javascript"><span class="token script-punctuation punctuation">=</span><span class="token punctuation">{</span><span class="token punctuation">{</span> flex<span class="token operator">:</span> <span class="token number">1</span><span class="token punctuation">,</span> justifyContent<span class="token operator">:</span> <span class="token string">"center"</span><span class="token punctuation">,</span> alignItems<span class="token operator">:</span> <span class="token string">"center"</span> <span class="token punctuation">}</span><span class="token punctuation">}</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-Try editing me! 🎉
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">Text</span></span><span class="token punctuation">></span></span><span class="token plain-text">
-</span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span><span class="token class-name">View</span></span><span class="token punctuation">></span></span>
-<span class="token punctuation">)</span><span class="token punctuation">;</span>
-<span class="token punctuation">}</span>
-
-<span class="token keyword">export</span> <span class="token keyword">default</span> YourApp<span class="token punctuation">;</span>
-  </code>
-</pre>
-  </div>
-  <div class="desktop-friendly-snack">
-    <div
-      data-snack-name="SecondPlayer"
-      data-snack-description="Example usage"
-      data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
-      data-snack-platform="web"
-      data-snack-supported-platforms="ios,android,web"
-      data-snack-preview="true"
-      style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
-    ></div>
-  </div>
+  <div
+    data-snack-name="SecondPlayer"
+    data-snack-description="Example usage"
+    data-snack-code="import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%20%7D%20from%20'react-native'%3B%0A%0Aconst%20YourApp%20%3D%20()%20%3D%3E%20%7B%0A%20%20%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7B%7B%20flex%3A%201%2C%20justifyContent%3A%20%22center%22%2C%20alignItems%3A%20%22center%22%20%7D%7D%3E%0A%20%20%20%20%20%20%20%20%3CText%3E%0A%20%20%20%20%20%20%20%20Try%20editing%20me!%20%F0%9F%8E%89%0A%20%20%20%20%20%20%20%20%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20%20%20)%3B%0A%7D%0A%0Aexport%20default%20YourApp%3B"
+    data-snack-platform="web"
+    data-snack-supported-platforms="ios,android,web"
+    data-snack-preview="true"
+    style="overflow:hidden;background:#fafafa;border:1px solid rgba(0,0,0,.08);border-radius:4px;height:505px;width:100%"
+  ></div>
 </div>
 
 <script async src="https://snack.expo.io/embed.js"></script>
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/prism-solarized-dark@1.0.1/prism-solarizeddark.css"
-/>
-<script type="text/javascript">
-  // From:
-  (function() {
-    "use strict";
-    if (typeof document === "undefined") {
-      // Not on browser
-      return;
-    }
-    document.addEventListener("DOMContentLoaded", init);
-
-    function init() {
-      var mobile = isMobile();
-
-      window.ExpoSnack && window.ExpoSnack.initialize();
-
-      var snackPlayerList = document.querySelectorAll(".snack-player");
-
-      // Either show interactive or static code block, depending on desktop or mobile
-      for (var i = 0; i < snackPlayerList.length; ++i) {
-        var snackPlayer = snackPlayerList[i];
-        var snackDesktopPlayer = snackPlayer.querySelectorAll(
-          ".desktop-friendly-snack"
-        )[0];
-        var plainCodeExample = snackPlayer.querySelectorAll(
-          ".mobile-friendly-snack"
-        )[0];
-
-        if (mobile) {
-          snackDesktopPlayer.remove();
-          plainCodeExample.style.display = "block";
-        } else {
-          plainCodeExample.remove();
-        }
-      }
-    }
-
-    // Primitive mobile detection
-    function isMobile() {
-      return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-        navigator.userAgent
-      );
-    }
-  })();
-</script>

--- a/website/plugins/remark-snackplayer/yarn.lock
+++ b/website/plugins/remark-snackplayer/yarn.lock
@@ -62,15 +62,6 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
-clipboard@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
-  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 collapse-white-space@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
@@ -117,11 +108,6 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 dotignore@^0.1.2:
   version "0.1.2"
@@ -225,13 +211,6 @@ glob@^7.1.6:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
-  dependencies:
-    delegate "^3.1.2"
 
 has-symbols@^1.0.1:
   version "1.0.1"
@@ -488,13 +467,6 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-prismjs@^1.21.0:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
-  integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
-  optionalDependencies:
-    clipboard "^2.0.0"
-
 regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -578,11 +550,6 @@ resumer@^0.0.0:
   dependencies:
     through "~2.3.4"
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
-
 side-channel@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.3.tgz#cdc46b057550bbab63706210838df5d4c19519c3"
@@ -658,11 +625,6 @@ through@^2.3.8, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 trim-trailing-lines@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
Not sure why the current site has a fallback for a code block when on mobile snackplayer scales well for mobile and does the same job ( albeit better, once the dark theme switch will be added )
<img width="404" alt="Screenshot_2020-10-03_at_2 20 41_PM" src="https://user-images.githubusercontent.com/11258286/95485450-5f6f7980-09af-11eb-8b17-d52a161b013a.png">

