### PR TITLE
update algolia config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -488,11 +488,8 @@ module.exports = {
     },
     algolia: {
       apiKey: '2c98749b4a1e588efec53b2acec13025',
-      indexName: 'react-native-versions',
-      algoliaOptions: {
-        facetFilters: ['tags:VERSION'],
-        hitsPerPage: 5,
-      },
+      indexName: 'react-native-v2',
+      contextualSearch: true,
     },
     googleAnalytics: {
       trackingID: 'UA-41298772-2',


### PR DESCRIPTION
Updates the Algolia config to use contextual search, and the new index for Docusaurus 2.

New config: 
https://github.com/algolia/docsearch-configs/commit/36654b79767aa7decdc570d20cd33f29294159d3

Note: the old index is still there and will keep being used by the v1 archived site, so v1 search won't break.

Note: this will only work after we upgrade Docusaurus to alpha 66 (next release, soon)